### PR TITLE
Fixing issue from a UnboundLocalError Exception

### DIFF
--- a/pydat/scripts/mongo_populate.py
+++ b/pydat/scripts/mongo_populate.py
@@ -212,6 +212,8 @@ def process_entry(insert_queue, collection, header, input_entry, options):
             details_copy = details.copy()
             for exclude in options.exclude:
                 del details_copy[exclude]
+            changed = set(details.items()) - set(current_entry['details'].items())
+            diff = len(set(details.items()) - set(current_entry['details'].items())) > 0
         elif options.include is not None:
             details_copy = {}
             for include in options.include:


### PR DESCRIPTION
When attempting an update with a recent quarterly dump we would get the following exception error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "./mongo_populate.py", line 173, in process_reworker
    process_entry(insert_queue, collection, work['header'], work['row'], options)
  File "./mongo_populate.py", line 232, in process_entry
    for ch in changed:
UnboundLocalError: local variable 'changed' referenced before assignment
